### PR TITLE
COMPASS-382 - Handle 'top' failure when # collections exceed doc size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-/* eslint camelcase:0, complexity: 1 */
+/* eslint camelcase:0, complexity: 0 */
 /**
  * MongoDB driver errors for humans.
  *
@@ -59,6 +59,8 @@ function translate(msg) {
     return new Mapping(boom.badRequest, 'Kerberos not detected on provided connection details');
   } else if (/socket hang up/.test(msg)) {
     return new Mapping(boom.serverTimeout, 'Socket could not establish connection to provided host and port');
+  } else if (/BSONObj size/.test(msg)) {
+    return new Mapping(boom.badImplementation, 'Response from server was too large to process');
   }
   return null;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongodb-js-errors",
   "description": "Helpers for handling errors from the MongoDB driver.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "scripts": {
     "fmt": "mongodb-js-fmt ./*.js test/*.js",
     "check": "mongodb-js-precommit ./*.js test/*.js",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,7 @@
 var errors = require('../');
 var assert = require('assert');
 var expect = require('chai').expect;
+var boom = require('boom');
 
 describe('mongodb-errors', function() {
   it('should work', function() {
@@ -33,6 +34,14 @@ describe('mongodb-errors', function() {
     context('when the regex does not match', function() {
       it('returns null', function() {
         expect(errors.translate('not an error')).to.equal(null);
+      });
+    });
+
+    context('when the error is internal', function() {
+      it('returns a ServerError', function() {
+        var result = errors.translate('BSONObj size: 26360608 (0x1923B20) is invalid. Size must be between 0 and 16793600(16MB)');
+        expect(result.message).to.equal('Response from server was too large to process');
+        expect(result.func).to.equal(boom.badImplementation);
       });
     });
   });


### PR DESCRIPTION
- Add a better error message for MaxBSONSize error returned from top when there are too many collections.
- See https://github.com/10gen/compass/pull/638.